### PR TITLE
feat: add sw64 support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openssh (1:9.9p2-0deepin2) unstable; urgency=medium
+
+  * feat: add sw64 support
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 18 Jun 2025 13:59:48 +0800
+
 openssh (1:9.9p2-0deepin1) unstable; urgency=medium
 
   * Update to 9.9p2, fixes CVE-2025-26465, CVE-2025-26466

--- a/debian/rules
+++ b/debian/rules
@@ -32,6 +32,10 @@ else
   RUN_TESTS :=
 endif
 
+ifeq ($(DEB_BUILD_ARCH), sw64)
+  CFLAGS += -fwrapv -fno-strict-overflow
+endif
+
 # Change the version string to reflect distribution
 SSH_EXTRAVERSION := $(DEB_VENDOR)-$(shell echo '$(DEB_VERSION)' | sed -e 's/.*-//; s/+salsaci+.*/+salsaci/')
 


### PR DESCRIPTION
sw64的gcc默认参数编译该项目会存在乘法溢出报错，因此添加'-fwrapv -fno-strict-overflow'规避该问题