### PR TITLE
Fix CVE-2025-32728, CVE-2025-61984, CVE-2025-61985, CVE-2026-3497

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+openssh (1:9.9p2-0deepin5) unstable; urgency=medium
+
+  * Apply patches from upstream:
+    - d/p/0033-upstream-Fix-logic-error-in-DisableForwarding-option.patch
+      Fixes: CVE-2025-32728
+    - d/p/0034-upstream-Make-a-copy-of-the-user-when-handling-ssh-l.patch
+      Fixes a UAF by xstrdup(optarg)
+    - d/p/0035-upstream-Improve-rules-for-expansion-of-username.patch
+      Fixes: CVE-2025-61984
+    - d/p/0036-upstream-don-t-allow-0-characters-in-url-encoded-str.patch
+      d/p/0037-Add-more-username-validity-checks.patch
+      Fixes: CVE-2025-61985
+    - d/p/gssapi.patch
+      Fixes: CVE-2026-3497
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Tue, 14 Apr 2026 11:20:19 +0800
+
 openssh (1:9.9p2-0deepin4) unstable; urgency=medium
 
   * fix: filter Uos or uos for lsb_release -is.

--- a/debian/patches/0033-upstream-Fix-logic-error-in-DisableForwarding-option.patch
+++ b/debian/patches/0033-upstream-Fix-logic-error-in-DisableForwarding-option.patch
@@ -1,0 +1,35 @@
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Wed, 9 Apr 2025 07:00:03 +0000
+Subject: upstream: Fix logic error in DisableForwarding option. This option
+
+was documented as disabling X11 and agent forwarding but it failed to do so.
+Spotted by Tim Rice.
+
+OpenBSD-Commit-ID: fffc89195968f7eedd2fc57f0b1f1ef3193f5ed1
+---
+ session.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/session.c b/session.c
+index 1c67f9f..3cd2c95 100644
+--- a/session.c
++++ b/session.c
+@@ -2176,7 +2176,8 @@ session_auth_agent_req(struct ssh *ssh, Session *s)
+ 	if ((r = sshpkt_get_end(ssh)) != 0)
+ 		sshpkt_fatal(ssh, r, "%s: parse packet", __func__);
+ 	if (!auth_opts->permit_agent_forwarding_flag ||
+-	    !options.allow_agent_forwarding) {
++	    !options.allow_agent_forwarding ||
++	    options.disable_forwarding) {
+ 		debug_f("agent forwarding disabled");
+ 		return 0;
+ 	}
+@@ -2571,7 +2572,7 @@ session_setup_x11fwd(struct ssh *ssh, Session *s)
+ 		ssh_packet_send_debug(ssh, "X11 forwarding disabled by key options.");
+ 		return 0;
+ 	}
+-	if (!options.x11_forwarding) {
++	if (!options.x11_forwarding || options.disable_forwarding) {
+ 		debug("X11 forwarding disabled in server configuration file.");
+ 		return 0;
+ 	}

--- a/debian/patches/0034-upstream-Make-a-copy-of-the-user-when-handling-ssh-l.patch
+++ b/debian/patches/0034-upstream-Make-a-copy-of-the-user-when-handling-ssh-l.patch
@@ -1,0 +1,25 @@
+From: "dtucker@openbsd.org" <dtucker@openbsd.org>
+Date: Sun, 2 Mar 2025 07:02:49 +0000
+Subject: upstream: Make a copy of the user when handling ssh -l, so that
+
+later during User token expansion we don't end up freeing a member of argv.
+Spotted by anton@'s regress tests.
+
+OpenBSD-Commit-ID: 2f671a4f5726b66d123b88b1fdd1a90581339955
+---
+ ssh.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ssh.c b/ssh.c
+index 925d5c0..fe4f7c4 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -1019,7 +1019,7 @@ main(int ac, char **av)
+ 			break;
+ 		case 'l':
+ 			if (options.user == NULL)
+-				options.user = optarg;
++				options.user = xstrdup(optarg);
+ 			break;
+ 
+ 		case 'L':

--- a/debian/patches/0035-upstream-Improve-rules-for-expansion-of-username.patch
+++ b/debian/patches/0035-upstream-Improve-rules-for-expansion-of-username.patch
@@ -1,0 +1,102 @@
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 00:29:09 +0000
+Subject: upstream: Improve rules for %-expansion of username.
+
+Usernames passed on the commandline will no longer be subject to
+% expansion. Some tools invoke ssh with connection information
+(i.e. usernames and host names) supplied from untrusted sources.
+These may contain % expansion sequences which could yield
+unexpected results.
+
+Since openssh-9.6, all usernames have been subject to validity
+checking. This change tightens the validity checks by refusing
+usernames that include control characters (again, these can cause
+surprises when supplied adversarially).
+
+This change also relaxes the validity checks in one small way:
+usernames supplied via the configuration file as literals (i.e.
+include no % expansion characters) are not subject to these
+validity checks. This allows usernames that contain arbitrary
+characters to be used, but only via configuration files. This
+is done on the basis that ssh's configuration is trusted.
+
+Pointed out by David Leadbeater, ok deraadt@
+
+OpenBSD-Commit-ID: e2f0c871fbe664aba30607321575e7c7fc798362
+---
+ ssh.c | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/ssh.c b/ssh.c
+index fe4f7c4..bce55af 100644
+--- a/ssh.c
++++ b/ssh.c
+@@ -649,6 +649,8 @@ valid_ruser(const char *s)
+ 	if (*s == '-')
+ 		return 0;
+ 	for (i = 0; s[i] != 0; i++) {
++		if (iscntrl((u_char)s[i]))
++			return 0;
+ 		if (strchr("'`\";&<>|(){}", s[i]) != NULL)
+ 			return 0;
+ 		/* Disallow '-' after whitespace */
+@@ -670,6 +672,7 @@ main(int ac, char **av)
+ 	struct ssh *ssh = NULL;
+ 	int i, r, opt, exit_status, use_syslog, direct, timeout_ms;
+ 	int was_addr, config_test = 0, opt_terminated = 0, want_final_pass = 0;
++	int user_on_commandline = 0;
+ 	char *p, *cp, *line, *argv0, *logfile;
+ 	char cname[NI_MAXHOST], thishost[NI_MAXHOST];
+ 	struct stat st;
+@@ -1018,8 +1021,10 @@ main(int ac, char **av)
+ 			}
+ 			break;
+ 		case 'l':
+-			if (options.user == NULL)
++			if (options.user == NULL) {
+ 				options.user = xstrdup(optarg);
++				user_on_commandline = 1;
++			}
+ 			break;
+ 
+ 		case 'L':
+@@ -1122,6 +1127,7 @@ main(int ac, char **av)
+ 			if (options.user == NULL) {
+ 				options.user = tuser;
+ 				tuser = NULL;
++				user_on_commandline = 1;
+ 			}
+ 			free(tuser);
+ 			if (options.port == -1 && tport != -1)
+@@ -1136,6 +1142,7 @@ main(int ac, char **av)
+ 				if (options.user == NULL) {
+ 					options.user = p;
+ 					p = NULL;
++					user_on_commandline = 1;
+ 				}
+ 				*cp++ = '\0';
+ 				host = xstrdup(cp);
+@@ -1157,8 +1164,6 @@ main(int ac, char **av)
+ 
+ 	if (!valid_hostname(host))
+ 		fatal("hostname contains invalid characters");
+-	if (options.user != NULL && !valid_ruser(options.user))
+-		fatal("remote username contains invalid characters");
+ 	options.host_arg = xstrdup(host);
+ 
+ 	/* Initialize the command to execute on remote host. */
+@@ -1440,6 +1445,14 @@ main(int ac, char **av)
+ 	cinfo->conn_hash_hex = ssh_connection_hash(cinfo->thishost,
+ 	    cinfo->remhost, cinfo->portstr, cinfo->remuser, cinfo->jmphost);
+ 
++	/*
++	 * Usernames specified on the commandline must be validated.
++	 * Conversely, usernames from getpwnam(3) or specified as literals
++	 * via configuration are not subject to validation.
++	 */
++	if (user_on_commandline && !valid_ruser(options.user))
++		fatal("remote username contains invalid characters");
++
+ 	/*
+ 	 * Expand tokens in arguments. NB. LocalCommand is expanded later,
+ 	 * after port-forwarding is set up, so it may pick up any local

--- a/debian/patches/0036-upstream-don-t-allow-0-characters-in-url-encoded-str.patch
+++ b/debian/patches/0036-upstream-don-t-allow-0-characters-in-url-encoded-str.patch
@@ -1,0 +1,36 @@
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 00:30:06 +0000
+Subject: upstream: don't allow \0 characters in url-encoded strings.
+
+Suggested by David Leadbeater, ok deraadt@
+
+OpenBSD-Commit-ID: c92196cef0f970ceabc1e8007a80b01e9b7cd49c
+---
+ misc.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/misc.c b/misc.c
+index e9b1298..3f4d285 100644
+--- a/misc.c
++++ b/misc.c
+@@ -990,7 +990,7 @@ urldecode(const char *src)
+ 	size_t srclen;
+ 
+ 	if ((srclen = strlen(src)) >= SIZE_MAX)
+-		fatal_f("input too large");
++		return NULL;
+ 	ret = xmalloc(srclen + 1);
+ 	for (dst = ret; *src != '\0'; src++) {
+ 		switch (*src) {
+@@ -998,9 +998,10 @@ urldecode(const char *src)
+ 			*dst++ = ' ';
+ 			break;
+ 		case '%':
++			/* note: don't allow \0 characters */
+ 			if (!isxdigit((unsigned char)src[1]) ||
+ 			    !isxdigit((unsigned char)src[2]) ||
+-			    (ch = hexchar(src + 1)) == -1) {
++			    (ch = hexchar(src + 1)) == -1 || ch == 0) {
+ 				free(ret);
+ 				return NULL;
+ 			}

--- a/debian/patches/0037-Add-more-username-validity-checks.patch
+++ b/debian/patches/0037-Add-more-username-validity-checks.patch
@@ -1,0 +1,81 @@
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Thu, 4 Sep 2025 03:04:44 +0000
+Subject: Add more username validity checks
+
+[cjwatson: Reduced from a more extensive upstream change, since OpenSSH
+< 10.0 doesn't support %-expansion of usernames.]
+
+OpenBSD-Regress-ID: ad4c12c70bdf1f959abfebd1637ecff1b49a484c
+
+Origin: backport, https://anongit.mindrot.org/openssh.git/commit/?id=f64701ca25795548a61614d0b13391d6dfa7f38c
+Author: Colin Watson <cjwatson@debian.org>
+Bug-Debian: https://bugs.debian.org/1117530
+Last-Update: 2026-01-09
+
+Patch-Name: CVE-2025-61984-tests.patch
+---
+ regress/percent.sh | 37 +++++++++++++++++++++++++++++++++++--
+ 1 file changed, 35 insertions(+), 2 deletions(-)
+
+diff --git a/regress/percent.sh b/regress/percent.sh
+index 354854f..66af7c9 100644
+--- a/regress/percent.sh
++++ b/regress/percent.sh
+@@ -29,6 +29,20 @@ trial()
+ 		    somehost true
+ 		got=`cat $OBJ/actual`
+ 		;;
++	user)
++		got=`${SSH} -F $OBJ/ssh_proxy -o $opt="$arg" -G \
++		    remuser@somehost | awk '$1=="'$opt'"{print $2}'`
++		;;
++	user-l)
++		# Also test ssh -l
++		got=`${SSH} -F $OBJ/ssh_proxy -l "$arg" -G \
++		    somehost | awk '$1=="'user'"{print $2}'`
++		;;
++	user-at)
++		# Also test user@host
++		got=`${SSH} -F $OBJ/ssh_proxy -G "$arg@somehost" | \
++		    awk '$1=="'user'"{print $2}'`
++		;;
+ 	userknownhostsfile)
+ 		# Move the userknownhosts file to what the expansion says,
+ 		# make sure ssh works then put it back.
+@@ -107,11 +121,11 @@ done
+ 
+ # Subset of above since we don't expand shell-style variables on anything that
+ # runs a command because the shell will expand those.
++FOO=bar
++export FOO
+ for i in controlpath identityagent forwardagent localforward remoteforward \
+     userknownhostsfile; do
+ 	verbose $tid $i dollar
+-	FOO=bar
+-	export FOO
+ 	trial $i '${FOO}' $FOO
+ done
+ 
+@@ -122,3 +136,22 @@ for i in controlpath identityagent forwardagent; do
+ 	trial $i '~' $HOME/
+ 	trial $i '~/.ssh' $HOME/.ssh
+ done
++
++# These should be not be expanded but rejected for containing shell characters.
++verbose $tid user-l noenv
++${SSH} -F $OBJ/ssh_proxy -l '${FOO}' -G somehost && fail "user-l expanded env"
++verbose $tid user-at noenv
++${SSH} -F $OBJ/ssh_proxy -G '${FOO}@somehost' && fail "user-at expanded env"
++
++FOO=`printf 'x\ay'`
++export FOO
++
++# These should be rejected as containing control characters.
++verbose $tid user-l badchar
++${SSH} -F $OBJ/ssh_proxy -l "${FOO}" -G somehost && fail "user-l expanded env"
++verbose $tid user-at badchar
++${SSH} -F $OBJ/ssh_proxy -G "${FOO}@somehost" && fail "user-at expanded env"
++
++# Literal control characters in config is acceptable
++verbose $tid user control-literal
++trial user "$FOO" "$FOO"

--- a/debian/patches/gssapi.patch
+++ b/debian/patches/gssapi.patch
@@ -1411,7 +1411,7 @@ index 40d688d62..15df591ca 100644
      const struct sshbuf *client_version,
 diff --git a/kexgssc.c b/kexgssc.c
 new file mode 100644
-index 000000000..2da431428
+index 000000000..5c4203ea4
 --- /dev/null
 +++ b/kexgssc.c
 @@ -0,0 +1,602 @@
@@ -1469,8 +1469,8 @@ index 000000000..2da431428
 +{
 +	struct kex *kex = ssh->kex;
 +	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER,
-+	    recv_tok = GSS_C_EMPTY_BUFFER,
-+	    gssbuf, msg_tok = GSS_C_EMPTY_BUFFER, *token_ptr;
++	    recv_tok = GSS_C_EMPTY_BUFFER, gssbuf = GSS_C_EMPTY_BUFFER,
++	    msg_tok = GSS_C_EMPTY_BUFFER, *token_ptr;
 +	Gssctxt *ctxt;
 +	OM_uint32 maj_status, min_status, ret_flags;
 +	struct sshbuf *server_blob = NULL;
@@ -1615,11 +1615,11 @@ index 000000000..2da431428
 +						fatal("Failed to read token: %s", ssh_err(r));
 +					/* If we're already complete - protocol error */
 +					if (maj_status == GSS_S_COMPLETE)
-+						sshpkt_disconnect(ssh, "Protocol error: received token when complete");
++						ssh_packet_disconnect(ssh, "Protocol error: received token when complete");
 +				} else {
 +					/* No token included */
 +					if (maj_status != GSS_S_COMPLETE)
-+						sshpkt_disconnect(ssh, "Protocol error: did not receive final token");
++						ssh_packet_disconnect(ssh, "Protocol error: did not receive final token");
 +				}
 +				if ((r = sshpkt_get_end(ssh)) != 0) {
 +					fatal("Expecting end of packet.");
@@ -1635,7 +1635,7 @@ index 000000000..2da431428
 +					fatal("sshpkt_get failed: %s", ssh_err(r));
 +				fatal("GSSAPI Error: \n%.400s", msg);
 +			default:
-+				sshpkt_disconnect(ssh, "Protocol error: didn't expect packet type %d",
++				ssh_packet_disconnect(ssh, "Protocol error: didn't expect packet type %d",
 +				    type);
 +			}
 +			token_ptr = &recv_tok;
@@ -1708,7 +1708,7 @@ index 000000000..2da431428
 +
 +	/* Verify that the hash matches the MIC we just got. */
 +	if (GSS_ERROR(ssh_gssapi_checkmic(ctxt, &gssbuf, &msg_tok)))
-+		sshpkt_disconnect(ssh, "Hash's MIC didn't verify");
++		ssh_packet_disconnect(ssh, "Hash's MIC didn't verify");
 +
 +	gss_release_buffer(&min_status, &msg_tok);
 +
@@ -1740,7 +1740,7 @@ index 000000000..2da431428
 +{
 +	struct kex *kex = ssh->kex;
 +	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER,
-+	    recv_tok = GSS_C_EMPTY_BUFFER, gssbuf,
++	    recv_tok = GSS_C_EMPTY_BUFFER, gssbuf = GSS_C_EMPTY_BUFFER,
 +            msg_tok = GSS_C_EMPTY_BUFFER, *token_ptr;
 +	Gssctxt *ctxt;
 +	OM_uint32 maj_status, min_status, ret_flags;
@@ -1910,11 +1910,11 @@ index 000000000..2da431428
 +						fatal("sshpkt failed: %s", ssh_err(r));
 +					/* If we're already complete - protocol error */
 +					if (maj_status == GSS_S_COMPLETE)
-+						sshpkt_disconnect(ssh, "Protocol error: received token when complete");
++						ssh_packet_disconnect(ssh, "Protocol error: received token when complete");
 +				} else {
 +					/* No token included */
 +					if (maj_status != GSS_S_COMPLETE)
-+						sshpkt_disconnect(ssh, "Protocol error: did not receive final token");
++						ssh_packet_disconnect(ssh, "Protocol error: did not receive final token");
 +				}
 +				break;
 +			case SSH2_MSG_KEXGSS_ERROR:
@@ -1927,7 +1927,7 @@ index 000000000..2da431428
 +					fatal("sshpkt failed: %s", ssh_err(r));
 +				fatal("GSSAPI Error: \n%.400s", msg);
 +			default:
-+				sshpkt_disconnect(ssh, "Protocol error: didn't expect packet type %d",
++				ssh_packet_disconnect(ssh, "Protocol error: didn't expect packet type %d",
 +				    type);
 +			}
 +			token_ptr = &recv_tok;
@@ -1989,7 +1989,7 @@ index 000000000..2da431428
 +
 +	/* Verify that the hash matches the MIC we just got. */
 +	if (GSS_ERROR(ssh_gssapi_checkmic(ctxt, &gssbuf, &msg_tok)))
-+		sshpkt_disconnect(ssh, "Hash's MIC didn't verify");
++		ssh_packet_disconnect(ssh, "Hash's MIC didn't verify");
 +
 +	gss_release_buffer(&min_status, &msg_tok);
 +
@@ -2019,10 +2019,10 @@ index 000000000..2da431428
 +#endif /* defined(GSSAPI) && defined(WITH_OPENSSL) */
 diff --git a/kexgsss.c b/kexgsss.c
 new file mode 100644
-index 000000000..1fd1d1e48
+index 000000000..7d50ffcd0
 --- /dev/null
 +++ b/kexgsss.c
-@@ -0,0 +1,478 @@
+@@ -0,0 +1,480 @@
 +/*
 + * Copyright (c) 2001-2009 Simon Wilkinson. All rights reserved.
 + *
@@ -2089,7 +2089,8 @@ index 000000000..1fd1d1e48
 +	 */
 +
 +	OM_uint32 ret_flags = 0;
-+	gss_buffer_desc gssbuf, recv_tok, msg_tok;
++	gss_buffer_desc gssbuf = GSS_C_EMPTY_BUFFER,
++	    recv_tok = GSS_C_EMPTY_BUFFER, msg_tok = GSS_C_EMPTY_BUFFER;
 +	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 +	Gssctxt *ctxt = NULL;
 +	struct sshbuf *shared_secret = NULL;
@@ -2168,7 +2169,7 @@ index 000000000..1fd1d1e48
 +				fatal("sshpkt failed: %s", ssh_err(r));
 +			break;
 +		default:
-+			sshpkt_disconnect(ssh,
++			ssh_packet_disconnect(ssh,
 +			    "Protocol error: didn't expect packet type %d",
 +			    type);
 +		}
@@ -2284,7 +2285,8 @@ index 000000000..1fd1d1e48
 +	 */
 +
 +	OM_uint32 ret_flags = 0;
-+	gss_buffer_desc gssbuf, recv_tok, msg_tok;
++	gss_buffer_desc gssbuf = GSS_C_EMPTY_BUFFER,
++	    recv_tok = GSS_C_EMPTY_BUFFER, msg_tok = GSS_C_EMPTY_BUFFER;
 +	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 +	Gssctxt *ctxt = NULL;
 +	struct sshbuf *shared_secret = NULL;
@@ -2345,7 +2347,7 @@ index 000000000..1fd1d1e48
 +		    min, nbits, max);
 +	kex->dh = mm_choose_dh(min, nbits, max);
 +	if (kex->dh == NULL) {
-+		sshpkt_disconnect(ssh, "Protocol error: no matching group found");
++		ssh_packet_disconnect(ssh, "Protocol error: no matching group found");
 +		fatal("Protocol error: no matching group found");
 +	}
 +
@@ -2385,7 +2387,7 @@ index 000000000..1fd1d1e48
 +				fatal("sshpkt failed: %s", ssh_err(r));
 +			break;
 +		default:
-+			sshpkt_disconnect(ssh,
++			ssh_packet_disconnect(ssh,
 +			    "Protocol error: didn't expect packet type %d",
 +			    type);
 +		}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -32,3 +32,8 @@ deepin-extra-version.patch
 deepin-ssh-connect-idle-timeout.patch
 deepin-ssh-keygen-privatekey-file-perm.patch
 add-sm-support.patch
+0033-upstream-Fix-logic-error-in-DisableForwarding-option.patch
+0034-upstream-Make-a-copy-of-the-user-when-handling-ssh-l.patch
+0035-upstream-Improve-rules-for-expansion-of-username.patch
+0036-upstream-don-t-allow-0-characters-in-url-encoded-str.patch
+0037-Add-more-username-validity-checks.patch


### PR DESCRIPTION
- d/p/0033-upstream-Fix-logic-error-in-DisableForwarding-option.patch
  Fixes: CVE-2025-32728
- d/p/0034-upstream-Make-a-copy-of-the-user-when-handling-ssh-l.patch
  Fixes a UAF by xstrdup(optarg)
- d/p/0035-upstream-Improve-rules-for-expansion-of-username.patch
  Fixes: CVE-2025-61984
- d/p/0036-upstream-don-t-allow-0-characters-in-url-encoded-str.patch
  d/p/0037-Add-more-username-validity-checks.patch
  Fixes: CVE-2025-61985
- d/p/gssapi.patch
  Fixes: CVE-2026-3497
