### PR TITLE
fix: duplicate output

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openssh (1:9.9p2-0deepin6) unstable; urgency=medium
+
+  * fix duplicate output.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 15 May 2026 16:27:44 +0800
+
 openssh (1:9.9p2-0deepin5) unstable; urgency=medium
 
   * Apply patches from upstream:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -37,3 +37,4 @@ add-sm-support.patch
 0035-upstream-Improve-rules-for-expansion-of-username.patch
 0036-upstream-don-t-allow-0-characters-in-url-encoded-str.patch
 0037-Add-more-username-validity-checks.patch
+uniontech-fix-duplicate-loginmsg.patch

--- a/debian/patches/uniontech-fix-duplicate-loginmsg.patch
+++ b/debian/patches/uniontech-fix-duplicate-loginmsg.patch
@@ -1,0 +1,32 @@
+From: Lu Peilong <lupeilong@uniontech.com>
+Subject: [PATCH] Fix duplicate PAM Text Info message on SSH login
+
+Bug: 333423
+
+Root cause:
+In privilege separation mode, the monitor process sends loginmsg
+(PAM_TEXT_INFO) to the child process twice:
+
+1. mm_answer_pam_account() sends loginmsg via MONITOR_ANS_PAM_ACCOUNT
+   (used as SSH2_MSG_USERAUTH_BANNER during auth phase)
+2. mm_answer_pty() sends loginmsg again during session setup
+   (displayed via PTY by display_loginmsg() in session.c)
+
+After mm_answer_pam_account() sends the loginmsg, it does not reset
+the buffer, so the PTY setup sends the same content again, resulting
+in duplicate "验证成功" messages on the client.
+
+Fix:
+Add sshbuf_reset(loginmsg) after mm_request_send() in
+mm_answer_pam_account() so the message is only sent once.
+
+--- a/monitor.c
++++ b/monitor.c
+@@ -1085,6 +1085,7 @@ mm_answer_pam_account(struct ssh *ssh, int sock, struct sshbuf *m)
+ 		fatal("%s: buffer error: %s", __func__, ssh_err(r));
+
+ 	mm_request_send(sock, MONITOR_ANS_PAM_ACCOUNT, m);
++	sshbuf_reset(loginmsg);
+
+ 	return (ret);
+ }


### PR DESCRIPTION
[Problem]
In OpenSSH 9.x (e.g., UOS V25), the client displays "验证成功" (Authentication successful) twice during SSH login.
In contrast, OpenSSH 7.x (e.g., UOS V20) only displays it once.

[Root Cause]
In the privsep (privilege separation) mode:
1. During the authentication phase, mm_answer_pam_account() sends the PAM_TEXT_INFO (loginmsg) to the child process via SSH2_MSG_USERAUTH_BANNER (type 53).
2. During the session phase, mm_answer_pty() sends the same loginmsg again when allocating the PTY, as the monitor's loginmsg buffer was not cleared. V25's new version of SSH triggers the first Banner send which was not active in V20, leading to the duplicate output.

[Solution]
Call sshbuf_reset(loginmsg) in mm_answer_pam_account() after the message is successfully sent to ensure the buffer is empty for subsequent session requests.

---

[问题描述]
在 OpenSSH 9.x 版本（如 UOS V25）中，通过 SSH 登录时客户端会显示两次“验证成功”。 相比之下，OpenSSH 7.x 版本（如 UOS V20）只显示一次。

[根因分析]
在特权分离模式下：
1. 认证阶段：mm_answer_pam_account() 通过 SSH2_MSG_USERAUTH_BANNER (type 53) 将 PAM_TEXT_INFO (loginmsg) 发送给子进程。
2. 会话阶段：由于 monitor 进程的 loginmsg 缓冲区未被重置，mm_answer_pty() 在分配 PTY 时会再次发送该残留信息。 V25 使用的新版本 SSH 启用了认证阶段的消息发送逻辑，而该逻辑在 V20 中未被触发，从而导致重复。

[修复方案]
在 mm_answer_pam_account() 发送完请求后调用 sshbuf_reset(loginmsg) 重置缓冲区， 确保后续会话请求不会再次发送已处理的消息。