### PR TITLE
fix: make lsb_release -i -s comparison case-insensitive in debian/rules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+openssh (1:10.0p1-7+deb13u4deepin2) unstable; urgency=medium
+
+  * fix: lsb_release -i -s returns "Uos"(uppercase) on UOS build hosts
+    - The ifeq condition compares against lowercase "uos", causing the
+      condition to fail and ssh.service to be enabled instead of disabled
+    - Add tr A-Z a-z pipe to make the comparison case-insensitive
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 01 Jul 2026 15:49:14 +0800
+
 openssh (1:10.0p1-7+deb13u4deepin1) unstable; urgency=medium
 
   * Fix duplicate PAM Text Info login message

--- a/debian/rules
+++ b/debian/rules
@@ -211,7 +211,7 @@ execute_after_dh_installinit:
 	dh_installsysusers
 
 override_dh_installsystemd:
-ifeq ($(shell lsb_release  -i -s),uos)
+ifeq ($(shell lsb_release -i -s | tr A-Z a-z),uos)
 	dh_installsystemd -popenssh-server --no-enable ssh.service
 else
 	dh_installsystemd -popenssh-server ssh.service


### PR DESCRIPTION
On UOS build hosts, `lsb_release -i -s` returns "Uos" (uppercase U), but the `ifeq` condition in `override_dh_installsystemd` compares against lowercase "uos", causing the condition to fail and `ssh.service` to be enabled instead of disabled (should be disabled on UOS).

Add `tr A-Z a-z` pipe to make the comparison case-insensitive.

**Fix:** `ifeq ($(shell lsb_release -i -s | tr A-Z a-z),uos)`

---

### Influence:
1. Verify ssh.service is disabled by default on UOS builds
2. Verify ssh.service remains enabled on non-UOS builds
3. Confirm debian/rules override_dh_installsystemd works correctly
4. Verify no regression for other architecture-specific conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)